### PR TITLE
Switch to intended npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/mattbryson/backbone.marionette.keyshortcuts",
   "dependencies": {
-    "marionette": "0.0.0",
+    "backbone.marionette": "2.x - 3.x",
     "mousetrap": "^1.5.3"
   }
 }


### PR DESCRIPTION
`marionette` on npm is not currently in use