### PR TITLE
Fix for Marionette 3.x compatibility

### DIFF
--- a/backbone.marionette.keyshortcuts.js
+++ b/backbone.marionette.keyshortcuts.js
@@ -19,7 +19,7 @@
         return factory(_ || root._, Backbone || root.Backbone, Marionette || root.Marionette, Mousetrap || root.Mousetrap);
       });
    } else if (typeof exports === 'object') {
-     module.exports = factory(require("underscore"), require("backbone"), require("marionette"), require("mousetrap"));
+     module.exports = factory(require("underscore"), require("backbone"), require("backbone.marionette"), require("mousetrap"));
    } else {
       // RequireJS isn't being used. Assume underscore and backbone are loaded in <script> tags
       factory(_, Backbone, Marionette, Mousetrap);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/mattbryson/backbone.marionette.keyshortcuts",
   "dependencies": {
-    "backbone.marionette": "https://github.com/klaronix/backbone.marionette.git#branches/v3.5.1",
+    "backbone.marionette": "https://github.com/klaronix/backbone.marionette-v3.5.1.git",
     "mousetrap": "^1.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/mattbryson/backbone.marionette.keyshortcuts",
   "dependencies": {
-    "backbone.marionette": "2.x - 3.x",
+    "backbone.marionette": "https://github.com/klaronix/backbone.marionette.git#branches/v3.5.1",
     "mousetrap": "^1.5.3"
   }
 }


### PR DESCRIPTION
In Marionette 3.x CollectionView is not inherited from View. Keyshortcuts thus won't be bound in CollectionViews.